### PR TITLE
Avoid pickle files for read number to name mapping

### DIFF
--- a/diagnosticTool_scripts/diagnostic_modules.py
+++ b/diagnosticTool_scripts/diagnostic_modules.py
@@ -118,7 +118,7 @@ def check_file(file1, out_dir, user_format, file2=False):
     Rename sequnce ids for SE or PE files to ensure
     consistency between kraken and kaiju (which modify
     id names). Create dictionaries containing real IDs and
-    renamed version and pickle. If data is PE, assert
+    renamed version. If data is PE, assert
     paired files have the same number of entries and if
     the paired reads are matched by choosing random
     entries and confirming the IDs match (optionally
@@ -127,8 +127,6 @@ def check_file(file1, out_dir, user_format, file2=False):
     if file2:
         ids1 = rename_seqIDs(file1, out_dir, user_format, paired=1)
         ids2 = rename_seqIDs(file2, out_dir, user_format, paired=2)
-        with open(os.path.join(out_dir, 'ids2.pkl'), 'wb') as pkl_dict:
-            pickle.dump(ids2, pkl_dict, protocol=pickle.HIGHEST_PROTOCOL)
 
         assert len(ids1) == len(ids2), \
             "Paired files have different number of reads"
@@ -145,9 +143,6 @@ def check_file(file1, out_dir, user_format, file2=False):
 
     with open(os.path.join(out_dir, "log_file.txt"), "a") as log_file:
         log_file.write("Number of sequences = " + str(list(ids1)[-1]) + "\n")
-
-    with open(os.path.join(out_dir, 'ids1.pkl'), 'wb') as pkl_dict:
-        pickle.dump(ids1, pkl_dict, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 def fastqc_trim(out_dir, file1, trim_minlen, threads, adapter_file, file2=False):

--- a/diagnosticTool_scripts/kodoja_search.py
+++ b/diagnosticTool_scripts/kodoja_search.py
@@ -171,8 +171,9 @@ def main():
     # Format kraken data and subset unclassified and non-host sequences
     log("Analyzing Kraken results\n")
     seq_reanalysis("kraken_table.txt", "kraken_labels.txt", args.output_dir,
-                   args.data_format, kraken_file1, kraken_file2)
-
+                   args.data_format, args.read1)
+    # TODO: Delay recovering read names until after kaiju has run,
+    # as then we only need to load the read number to name mapping once.
     t4 = time.time()
 
     # Kaiju classification of all sequences or subset sequences
@@ -187,7 +188,7 @@ def main():
     # Merge results
     log("Analyzing Kraken and Kaiju results\n")
     result_analysis(args.output_dir, "kraken_VRL.txt", "kaiju_table.txt", "kaiju_labels.txt",
-                    args.host_subset)
+                    args.host_subset, args.data_format, args.read1)
     t6 = time.time()
 
     # Create log file


### PR DESCRIPTION
Previously ``kodoja_search.py`` would create files ``ids1.pkl`` and ``ids2.pkl`` in the Python pickle format holding the mapping from our internal read names (actually just the read number starting from 1) to the original read description. This renaming was done in order to workaround naming expectation conflicts found in the early development of kodoja.

These pickle files were used in parsing the Kraken and Kaiju output in order to restore the original read names, and also used as input for ``kodoja_retrieve.py``.

By avoiding the pickle files, we can reduce the number of input files needed for ``kodoja_retrieve.py``, which should make it much easier to integrate into Galaxy.

Instead of the pickle files, I now go back to the input read file (FASTA or FASTQ), and parse that to build up the name mapping needed. There is scope to optimise this as I think we could do this only once, rather then twice (after each tool).

I have not looked at the relative performance on a real dataset - loading a pickle file should be faster than parsing the FASTA or FASTQ again, but for the tests this is insignificant.

If that is significant, we could just change ``kodoja_retrieve.py`` to use the read file, and treat the pickle files as an internal implementation detail as temporary files.